### PR TITLE
Add video title fetching and display in section management

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -33,6 +33,8 @@ jobs:
         run: npm ci
       - name: Build
         run: npm run build
+        env:
+          VITE_REACT_APP_YOUTUBE_API_KEY: ${{ secrets.VITE_REACT_APP_YOUTUBE_API_KEY }}
       - name: Setup Pages
         uses: actions/configure-pages@v4
       - name: Upload artifact


### PR DESCRIPTION
* セクションデータ構造に`videoTitle`を含めるように更新。
* `fetchVideoTitle`関数を実装し、YouTube APIから動画タイトルを取得。
* `handleLoadVideo`および`saveSection`関数を修正し、取得した動画タイトルを利用。
* ビルド処理にて環境変数`VITE_REACT_APP_YOUTUBE_API_KEY`を使用できるように`.github/workflows/deploy.yml`を更新。