### PR TITLE
Create video list

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1645,6 +1645,20 @@
       "dev": true,
       "license": "ISC"
     },
+    "node_modules/fsevents": {
+      "version": "2.3.3",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
+      "integrity": "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==",
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
+      }
+    },
     "node_modules/glob-parent": {
       "version": "6.0.2",
       "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-6.0.2.tgz",
@@ -2694,9 +2708,9 @@
       }
     },
     "node_modules/vite": {
-      "version": "6.2.2",
-      "resolved": "https://registry.npmjs.org/vite/-/vite-6.2.2.tgz",
-      "integrity": "sha512-yW7PeMM+LkDzc7CgJuRLMW2Jz0FxMOsVJ8Lv3gpgW9WLcb9cTW+121UEr1hvmfR7w3SegR5ItvYyzVz1vxNJgQ==",
+      "version": "6.2.3",
+      "resolved": "https://registry.npmjs.org/vite/-/vite-6.2.3.tgz",
+      "integrity": "sha512-IzwM54g4y9JA/xAeBPNaDXiBF8Jsgl3VBQ2YQ/wOY6fyW3xMdSoltIV3Bo59DErdqdE6RxUfv8W69DvUorE4Eg==",
       "license": "MIT",
       "dependencies": {
         "esbuild": "^0.25.0",

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -117,25 +117,29 @@ function App() {
       const response = await fetch(
         `https://www.googleapis.com/youtube/v3/videos?id=${videoId}&part=snippet&key=${apiKey}`,
       );
-      const data = await response.json();
-      if (data.items.length > 0) {
-        return data.items[0].snippet.title;
+      if (response.status !== 200) {
+        console.error(`Error fetching video title: ${response.status} ${response.statusText}`);
+        return 'Anonymous';
+      } else {
+        const data = await response.json();
+        if (data.items.length > 0) {
+          return data.items[0].snippet.title;
+        }
       }
     } catch (error) {
       console.error('Error fetching video title:', error);
     }
   };
 
-  const handleLoadVideo = async () => {
-    setVideoId(tempVideoId);
-
-    const title = await fetchVideoTitle(tempVideoId);
+  const handleLoadVideo = async (videoId: string) => {
+    const title: string = await fetchVideoTitle(videoId);
     setVideoTitle(title);
-
     const storedSections = JSON.parse(
-      localStorage.getItem(tempVideoId) || '[]',
+      localStorage.getItem(videoId) || '[]',
     );
     setSections(storedSections);
+    setVideoId(videoId);
+    setTempVideoId('');
   };
 
   const handleStoredVideoClick = async (
@@ -144,10 +148,9 @@ function App() {
   ) => {
     setVideoId(videoId);
     setVideoTitle(videoTitle);
-    setTempVideoId(videoId);
 
     const storedSections = JSON.parse(
-      localStorage.getItem(tempVideoId) || '[]',
+      localStorage.getItem(videoId) || '[]',
     );
     setSections(storedSections);
   };
@@ -155,7 +158,6 @@ function App() {
   const handleClearVideo = () => {
     setActiveSectionId(0);
     setVideoId('');
-    setTempVideoId('');
     setStartHours(0);
     setStartMinutes(0);
     setStartSeconds(0);
@@ -355,16 +357,15 @@ function App() {
                   value={tempVideoId}
                   onChange={(e) => setTempVideoId(e.target.value)}
                   className={
-                    'border rounded p-2 w-full border-gray-300 disabled:bg-gray-200 disabled:text-gray-500'
+                    'border rounded p-2 w-full border-gray-300'
                   }
-                  disabled={videoId !== ''}
                 />
                 <button
                   type={'button'}
-                  onClick={videoId ? handleClearVideo : handleLoadVideo}
+                  onClick={() => handleLoadVideo(tempVideoId)}
                   className="ml-2 p-2 rounded bg-black text-white"
                 >
-                  {videoId ? 'Clear' : 'Load'}
+                  Load
                 </button>
               </div>
             </div>

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -369,79 +369,79 @@ function App() {
                   type="text"
                   value={tempVideoId}
                   onChange={(e) => setTempVideoId(e.target.value)}
-                  className={
-                    'border rounded p-2 w-full border-gray-300'
-                  }
+                  className={'border rounded p-2 w-full textbox'}
                 />
                 <button
                   type={'button'}
                   onClick={() => handleLoadVideo(tempVideoId)}
-                  className="ml-2 p-2 rounded bg-black text-white"
+                  className="ml-2 bg-black text-white btn"
                 >
                   Load
                 </button>
               </div>
             </div>
           )}
-          <hr className="my-4 border-gray-300"/>
           {!videoId && videos.length > 0 && (
             <div className="mt-2">
+              <hr className="my-4 border-gray-300" />
               <h2 className="text-sm font-bold">Stored Videos</h2>
-              {videos.map((video) => (
-                <div
-                  key={video.videoId}
-                  className="p-2 rounded"
-                  onClick={() =>
-                    handleStoredVideoClick(video.videoId, video.videoTitle)
-                  }
-                >
-                  <div className="truncate">{video.videoTitle}</div>
-                  <div className="text-sm">
-                    ({video.videoId})
-                  </div>
-                </div>
-              ))}
+              <div className="flex-col space-y-2">
+                {videos.map((video) => (
+                  <button
+                    type={'button'}
+                    key={video.videoId}
+                    className="card"
+                    onClick={() =>
+                      handleStoredVideoClick(video.videoId, video.videoTitle)
+                    }
+                  >
+                    <div className="truncate">{video.videoTitle}</div>
+                    <div className="text-xs text-gray-600">{video.videoId}</div>
+                  </button>
+                ))}
+              </div>
             </div>
           )}
           {videoId && sections.length > 0 && (
             <div className="mt-2">
               <h2 className="text-sm font-bold">Sections</h2>
-              {sections.map((section) => (
-                <div
-                  key={section.id}
-                  className={`p-2 flex items-center rounded ${
-                    activeSectionId === section.id ? 'bg-gray-100' : ''
-                  }`}
-                  onClick={() => handleClickSection(section)}
-                >
-                  <div className="flex-1 overflow-hidden">
-                    <div className="text-sm">
-                      <span className="font-bold mr-2">{section.id}</span>
-                      {section.startHours}:{formatSeconds(section.startMinutes)}
-                      :{formatSeconds(section.startSeconds)}-{section.endHours}:
-                      {formatSeconds(section.endMinutes)}:
-                      {formatSeconds(section.endSeconds)}
-                    </div>
-                    {section.note && (
-                      <div className="mt-1 text-sm text-gray-600 truncate">
-                        {section.note}
-                      </div>
-                    )}
-                  </div>
-                  <button
-                    type={'button'}
-                    onClick={(e) => {
-                      e.stopPropagation();
-                      deleteSection(section.id);
-                    }}
-                    className="p-2 border rounded border-gray-300 bg-white"
+              <div className="flex-col items-center space-y-2">
+                {sections.map((section) => (
+                  <div
+                    key={section.id}
+                    className={`flex-col card ${
+                      activeSectionId === section.id ? 'bg-slate-200' : ''
+                    }`}
+                    onClick={() => handleClickSection(section)}
                   >
-                    <span className="sr-only">Delete</span>
-                    <FaRegTrashAlt/>
-                  </button>
-                </div>
-              ))}
-              <hr className="my-4 border-gray-300"/>
+                    <div className="flex justify-between text-sm">
+                      <div>
+                        <span className="font-bold mr-2">{section.id}</span>
+                        {section.startHours}:
+                        {formatSeconds(section.startMinutes)}:
+                        {formatSeconds(section.startSeconds)}-{section.endHours}
+                        :{formatSeconds(section.endMinutes)}:
+                        {formatSeconds(section.endSeconds)}
+                      </div>
+                      <button
+                        type={'button'}
+                        onClick={(e) => {
+                          e.stopPropagation();
+                          deleteSection(section.id);
+                        }}
+                        className="text-slate-800 hover:text-slate-500 active:text-slate-500"
+                      >
+                        <span className="sr-only">Delete</span>
+                        <FaRegTrashAlt />
+                      </button>
+                    </div>
+                    <div className="text-xs text-gray-600 truncate">
+                      {section.note}
+                    </div>
+                  </div>
+                ))}
+              </div>
+              <hr className="my-4 border-gray-300" />
             </div>
           )}
           {videoId && (
@@ -457,7 +457,7 @@ function App() {
                     type="tel"
                     value={tempStartHours}
                     onChange={(e) => setTempStartHours(Number(e.target.value))}
-                    className="border rounded p-2 w-full border-gray-300 disabled:bg-gray-200 disabled:text-gray-500"
+                    className="border rounded p-2 w-full textbox"
                   />
                   <span className="mx-1">:</span>
                   <label htmlFor="startMinutes" className="sr-only">
@@ -470,7 +470,7 @@ function App() {
                     onChange={(e) =>
                       setTempStartMinutes(Number(e.target.value))
                     }
-                    className="border rounded p-2 w-full border-gray-300 disabled:bg-gray-200 disabled:text-gray-500"
+                    className="border rounded p-2 w-full textbox"
                   />
                   <span className="mx-1">:</span>
                   <label htmlFor="startSeconds" className="sr-only">
@@ -483,7 +483,7 @@ function App() {
                     onChange={(e) =>
                       setTempStartSeconds(Number(e.target.value))
                     }
-                    className="border rounded p-2 w-full border-gray-300 disabled:bg-gray-200 disabled:text-gray-500"
+                    className="border rounded p-2 w-full textbox"
                   />
                   <button
                     type={'button'}
@@ -494,7 +494,7 @@ function App() {
                         setTempStartSeconds,
                       )
                     }
-                    className="ml-2 p-2 rounded bg-black text-white"
+                    className="ml-2 btn btn-secondary"
                   >
                     Now
                   </button>
@@ -511,7 +511,7 @@ function App() {
                     type="tel"
                     value={tempEndHours}
                     onChange={(e) => setTempEndHours(Number(e.target.value))}
-                    className="border rounded p-2 w-full border-gray-300 disabled:bg-gray-200 disabled:text-gray-500"
+                    className="border rounded p-2 w-full textbox"
                   />
                   <span className="mx-1">:</span>
                   <label htmlFor="endMinutes" className="sr-only">
@@ -522,7 +522,7 @@ function App() {
                     type="tel"
                     value={formatSeconds(tempEndMinutes)}
                     onChange={(e) => setTempEndMinutes(Number(e.target.value))}
-                    className="border rounded p-2 w-full border-gray-300 disabled:bg-gray-200 disabled:text-gray-500"
+                    className="border rounded p-2 w-full textbox"
                   />
                   <span className="mx-1">:</span>
                   <label htmlFor="endSeconds" className="sr-only">
@@ -533,7 +533,7 @@ function App() {
                     type="tel"
                     value={formatSeconds(tempEndSeconds)}
                     onChange={(e) => setTempEndSeconds(Number(e.target.value))}
-                    className="border rounded p-2 w-full border-gray-300 disabled:bg-gray-200 disabled:text-gray-500"
+                    className="border rounded p-2 w-full textbox"
                   />
                   <button
                     type={'button'}
@@ -544,7 +544,7 @@ function App() {
                         setTempEndSeconds,
                       )
                     }
-                    className="ml-2 p-2 rounded bg-black text-white"
+                    className="ml-2 btn btn-secondary"
                   >
                     Now
                   </button>
@@ -555,13 +555,13 @@ function App() {
                 <textarea
                   value={note}
                   onChange={(e) => setNote(e.target.value)}
-                  className="border rounded p-2 w-full border-gray-300"
+                  className="w-full textbox"
                 />
               </div>
               <button
                 type={'button'}
                 onClick={() => saveSection()}
-                className="mt-4 p-2 w-full rounded bg-black text-white"
+                className="mt-4 w-full btn btn-primary"
               >
                 {activeSectionId !== 0 ? 'Update Section' : 'Add Section'}
               </button>
@@ -569,13 +569,13 @@ function App() {
           )}
           {videoId && (
             <>
-              <hr className="my-4 border-gray-300"/>
+              <hr className="my-4 border-gray-300" />
               <button
                 type={'button'}
                 onClick={handleClearVideo}
-                className="p-2 w-full rounded flex items-center justify-center bg-black text-white"
+                className="w-full flex items-center justify-center btn btn-secondary"
               >
-                <GoVideo className="mr-2 text-lg"/>
+                <GoVideo className="mr-2 text-lg" />
                 Other videos
               </button>
             </>

--- a/src/index.css
+++ b/src/index.css
@@ -1,1 +1,35 @@
 @import "tailwindcss";
+
+@layer base {
+    body {
+        @apply
+        bg-slate-100
+    }
+    .textbox {
+        @apply
+        p-2 rounded
+        border border-gray-300
+        bg-slate-50
+    }
+    .btn {
+        @apply
+        p-2 rounded
+    }
+    .btn-primary {
+        @apply
+        bg-slate-800 hover:bg-slate-700 active:bg-slate-700
+        text-white
+    }
+    .btn-secondary {
+        @apply
+        bg-slate-200 hover:bg-slate-300 active:bg-slate-300
+        text-slate-800
+    }
+    .card {
+        @apply
+        p-2 rounded w-full
+        border border-gray-200
+        bg-slate-50 hover:bg-white active:bg-white
+        text-left;
+    }
+}


### PR DESCRIPTION
動画ごとにセクションを表示するようにした。

### 状態管理のリファクタリング
* セクション識別のために`key`を`id`に置き換え、関連する状態変数を更新。
* `isRepeating`状態を削除し、`activeSectionId`を使用するようにロジックをリファクタリング。

### ローカルストレージの処理
* 動画とセクションをローカルストレージに保存および取得する機能を追加。
* セクション保存ロジックを更新し、動画IDキーの下にセクションをローカルストレージに保存。

### ユーザーインターフェースの強化
* 保存された動画とセクションを表示し、ユーザーがそれらを読み込みおよび削除できるUI要素を追加。
* CSSクラスを使用してボタンと入力スタイルをリファクタリング。